### PR TITLE
Added missing options variable

### DIFF
--- a/src/PandaDoc.php
+++ b/src/PandaDoc.php
@@ -77,7 +77,7 @@ abstract class PandaDoc
         $options = array_merge_recursive($headers, $options);
 
         if (!empty($options['query'])) {
-            $options['query'] = http_build_query(['query']);
+            $options['query'] = http_build_query($options['query']);
         }
 
         return $this->handleRequest($method, $resource, $options);


### PR DESCRIPTION
Missing options variable, was creating query string as "0=query", where it should be flattening the user supplied query array.